### PR TITLE
fix loading customized config.js

### DIFF
--- a/mappercore/conf/kepler_mapper.py
+++ b/mappercore/conf/kepler_mapper.py
@@ -19,7 +19,7 @@ class KeplerMapperConfig:
 
     def configure(self, server):
         server.register_function('run_mapper', self.run_mapper)
-        server.set_js_initializer(self._js_initializer)
+        server.set_config_js(self._js_initializer)
 
         if self._user_config:
             server.set_user_specs(self._user_config)

--- a/mappercore/server.py
+++ b/mappercore/server.py
@@ -24,7 +24,11 @@ class Server:
         self._should_load_config_js = self._config_js_exists()
 
         self._conf = conf
-        self._js_initializer = None
+        self._config_js = None
+
+        if self._config_js_exists():
+            self._config_js = 'modules/config'
+
         self._user_config = None
 
         self._users = users
@@ -48,11 +52,11 @@ class Server:
     def register_function(self, name, func):
         self._functions[name] = func
 
-    def set_js_initializer(self, module):
-        self._js_initializer = module
+    def set_config_js(self, module):
+        self._config_js = module
 
     def set_user_specs(self, spec_file):
-        with open(spec_file) as json_file:  
+        with open(spec_file) as json_file:
             user_config = json.load(json_file)
 
         self._user_config = user_config
@@ -160,8 +164,7 @@ class Server:
     def _route_index(self):
         return render_template('core/index.html',
                                title=self.title,
-                               should_load_config_js=self._should_load_config_js,
-                               js_initializer=self._js_initializer,
+                               config_js=self._config_js,
                                user_config=self._user_config)
 
     def _load_config_json(self):

--- a/static/modules/Block.js
+++ b/static/modules/Block.js
@@ -7,6 +7,7 @@ define(function () {
 
   const { b: { View, Model } } = window;
 
+
   return View.extend({
 
     initialize: function (config) {

--- a/static/modules/Setup.js
+++ b/static/modules/Setup.js
@@ -66,6 +66,7 @@ window.jQuery(function () {
       }
       return variable;
     };
+    window.mapper_loaded = true;
   });
 
 });

--- a/static/modules/blocks/FixedDataLoader.js
+++ b/static/modules/blocks/FixedDataLoader.js
@@ -28,7 +28,7 @@ define((require) => {
       });
 
       this.on('error', (error) => {
-        console.log(error);
+        console.error(error);
       });
     },
 

--- a/static/modules/graph/Plugin.js
+++ b/static/modules/graph/Plugin.js
@@ -39,12 +39,12 @@ define(() => {
 
     pause() {
       this.paused = true;
-      console.log('[' + this.constructor.name + '] paused');
+      console.debug('[' + this.constructor.name + '] paused');
     }
 
     resume() {
       this.paused = false;
-      console.log('[' + this.constructor.name + '] resume');
+      console.debug('[' + this.constructor.name + '] resume');
     }
   }
 });

--- a/static/modules/graph/Tool.js
+++ b/static/modules/graph/Tool.js
@@ -41,29 +41,29 @@ define(function () {
       if (!this.name || !this.label) {
         throw "A graph mode should have a name and a label.";
       }
-      console.log(`[${this.name}] willMount`);
+      console.debug(`[${this.name}] willMount`);
     }
 
     didMount() {
-      console.log(`[${this.name}] didMount`);
+      console.debug(`[${this.name}] didMount`);
     }
 
     willActivate() {
-      console.log(`[${this.name}] willActivate`);
+      console.debug(`[${this.name}] willActivate`);
     }
 
     didActivate() {
       this.activated = true;
-      console.log(`[${this.name}] didActivate`);
+      console.debug(`[${this.name}] didActivate`);
     }
 
     willDeactivate() {
-      console.log(`[${this.name}] willDeactivate`);
+      console.debug(`[${this.name}] willDeactivate`);
     }
 
     didDeactivate() {
       this.activated = false;
-      console.log(`[${this.name}] didDeactivate`);
+      console.debug(`[${this.name}] didDeactivate`);
     }
   };
 });

--- a/static/modules/graph/plugins/ForceSimulation.js
+++ b/static/modules/graph/plugins/ForceSimulation.js
@@ -15,7 +15,6 @@ define((require) => {
 
     didMount() {
       super.didMount();
-      console.log('force-simulation');
       this.events.listenTo(this.graph, 'didRender', () => {
         this._graphDidRender();
       });

--- a/static/templates/index.html
+++ b/static/templates/index.html
@@ -8,23 +8,37 @@
   <script src="/core/vendors/jquery.min.js"></script>
   <script src="/core/vendors/bootstrap.bundle.min.js"></script>
   <script src="/core/vendors/require.min.js"></script>
-  <script src="/core/modules/Setup.js" defer></script>
+  <script src="/core/modules/Setup.js"></script>
   {% block head %}{% endblock %}
 </head>
 <body>
 <div id="root" class="container-fluid"></div>
 
 <!-- User configuration -->
-<script type="text/javascript" >
-  var user_specs={{ user_config|tojson|safe }}
+<script type="text/javascript">
+  var user_specs = {{ user_config|tojson|safe }}
 </script>
 
 
 <!-- modules -->
 <script type="text/javascript" defer>
-  {% if js_initializer %}
-    require(['{{ js_initializer }}']);
-  {% endif %}
+  $(document).ready(function () {
+    var loadChecked = 0;
+    function waitForLoaded() {
+      loadChecked += 1;
+      if (loadChecked > 100) {
+        return ;
+      }
+      if (typeof window.mapper_loaded !== "undefined") {
+        {% if js_initializer %}
+          require(['{{ js_initializer }}']);
+        {% endif %}
+      } else {
+        setTimeout(waitForLoaded, 250);
+      }
+    }
+    waitForLoaded();
+  });
 </script>
 
 {# Enable live reload when in debugging mode.

--- a/static/templates/index.html
+++ b/static/templates/index.html
@@ -30,8 +30,8 @@
         return ;
       }
       if (typeof window.mapper_loaded !== "undefined") {
-        {% if js_initializer %}
-          require(['{{ js_initializer }}']);
+        {% if config_js %}
+          require(['{{ config_js }}']);
         {% endif %}
       } else {
         setTimeout(waitForLoaded, 250);


### PR DESCRIPTION
Users need a `config.js` to customize UI. But when the `config.js` is being loaded, the `Setup.js` may not be loaded.

This pull request added a checker to wait for the loading of `Setup.js`.

And this pull request rename the `js_initializer` to `config_js`. 