### PR TITLE
Correct cubical cover computation

### DIFF
--- a/app/cover.py
+++ b/app/cover.py
@@ -188,11 +188,11 @@ class Cover:
         inset = (ranges - inner_range) / 2
 
         # |range| / (2n ( 1 - p))
-        radius = ranges / (2 * (n_cubes) * (1 - perc_overlap))
+        radius = ranges / (2 * ((n_cubes) - (n_cubes - 1) * perc_overlap))
 
         # centers are fixed w.r.t perc_overlap
         zip_items = list(bounds)  # work around 2.7,3.4 weird behavior
-        zip_items.extend([n_cubes, inset])
+        zip_items.extend([n_cubes, radius])
         centers_per_dimension = [
             np.linspace(b + r, c - r, num=n) for b, c, n, r in zip(*zip_items)
         ]


### PR DESCRIPTION
Previously cubical cover over counted the number of intersections. This corrects the over-counting. This problem was inherited from kepler mapper. For a more thorough discussion of what exactly is happening see https://github.com/scikit-tda/kepler-mapper/pull/242.